### PR TITLE
Add some copy on our culture to the job ad

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,10 +168,12 @@ a {
     <p>Lägenhetsbyte.se söker nu en frontend-utvecklare som vill bygga en användarupplevelse utöver det vanliga.</p>
 
     <p>Du ansvarar för användarupplevelsen och den tekniska arkitekturen på klientsidan av Lägenhetsbyte.se, med stöd av de andra fem utvecklarna i teamet.</p>
-    
+
     <h2>Mer om hur vi jobbar</h2>
-    
-    <p>Vi är ett litet team med stort inflytande och samarbete. Vi värdesätter transparens, arbetar iterativt och inkrementellt samtidigt som vi söker ständig förbättring för att bli bättre och effektivare både som individer och team.</p>
+
+    <p>Vi är ett litet team med stort inflytande och samarbete.</p>
+
+    <p>Vi värdesätter transparens, arbetar med små leveranser (continuous delivery) och söker ständig förbättring för att bli bättre och effektivare både som individer och team.</p>
 
     <p>Vår backend använder i huvudsak ASP.NET MVC, men du behöver inte ha någon erfarenhet av det. Vårt mål är att jobba med teknologi som stödjer vår vision och ger oss självförtroende vårt arbete.</p>
 

--- a/index.html
+++ b/index.html
@@ -168,6 +168,14 @@ a {
     <p>Lägenhetsbyte.se söker nu en frontend-utvecklare som vill bygga en användarupplevelse utöver det vanliga.</p>
 
     <p>Du ansvarar för användarupplevelsen och den tekniska arkitekturen på klientsidan av Lägenhetsbyte.se, med stöd av de andra fem utvecklarna i teamet.</p>
+    
+    <h2>Mer om hur vi jobbar</h2>
+    
+    <p>Vi är ett litet team med stort inflytande och samarbete. Vi värdesätter transparens, arbetar iterativt och inkrementellt samtidigt som vi söker ständig förbättring för att bli bättre och effektivare både som individer och team.</p>
+
+    <p>Vår backend använder i huvudsak ASP.NET MVC, men du behöver inte ha någon erfarenhet av det. Vårt mål är att jobba med teknologi som stödjer vår vision och ger oss självförtroende vårt arbete.</p>
+
+    <p>Frontend består huvudsakligen av Angular och Foundation, men ska i stort sett bytas ut helt och hållet för att möta den moderna användarens förväntningar på en snabb, stabil och tillgänglig webb.</p>
 
     <h2>Du har tidigare erfarenhet av</h2>
 


### PR DESCRIPTION
I asked a few peeps for some external feedback on the job ad for our front-end position.

They liked the ad, but felt that some information about _us_—our stack and our culture—were missing.

This pull request attempts to remedy that problem.
